### PR TITLE
feature/atomic-deployments - Adding flag --atomic in order to remove …

### DIFF
--- a/scripts/deployer/scripts/deploy_helm.py
+++ b/scripts/deployer/scripts/deploy_helm.py
@@ -46,7 +46,7 @@ def install_helm_on_aws(aws_credentials, aws_region, aws_cluster, chart_name, ch
 
 def install_helm(chart_name, chart_file):
     click.echo(f"Helm deploy {chart_name} {chart_file}")
-    sh(f"helm upgrade {chart_name} {chart_file} --install")
+    sh(f"helm upgrade {chart_name} {chart_file} --install --atomic")
 
 def helm_package_and_push(chart_name, app_version, deploy_env):
     gcs_bucket_name = f"gs://volanty-charts-{deploy_env}/{chart_name}"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -43,7 +43,7 @@ helm gcs push "$chart_file" private --force
 # Deploy on GCP
 if [ "$deployType" == "GCP" ] || [ "$deployType" == "MULTI" ]; then
     echo "Deploy on GCP"
-    helm upgrade "${CHART_NAME}" "${chart_file}" --install
+    helm upgrade "${CHART_NAME}" "${chart_file}" --install --atomic
 fi
 
 # Deploy on AWS
@@ -59,5 +59,5 @@ if [ "$deployType" == "AWS" ] || [ "$deployType" == "MULTI" ]; then
     aws configure set aws_secret_access_key ${aws_secret_access_key}
     aws configure set default.region ${region}
     aws eks update-kubeconfig --name "${awsCluster}"
-    helm upgrade "${CHART_NAME}" "${chart_file}" --install
+    helm upgrade "${CHART_NAME}" "${chart_file}" --install --atomic
 fi


### PR DESCRIPTION
## Esse PR adiciona a flag `--atomic` no upgrade de uma _release_

### Motivação:  
A flag `--atomic` desinstala manifestos de recursos do Kubernetes já aplicados em caso de falha de instalação ou upgrade de uma _release_.

### Exemplo de caso de uso
Se uma _release_ possui um template de `Deployment` e um de `Service`, e, o `Service` falhar durante a operação, o manifesto aplicado do `Deployment` também será desinstalado.

Assim não haverá manifestos do Kubernetes perdidos no cluster.

Mais informações em: [Helm Install](https://helm.sh/pt/docs/helm/helm_install/#op%C3%A7%C3%B5es)


## Esse PR segue:
- [x] [DCO Agreement](https://developercertificate.org/)

Signed-off-by: Jeremias Moraes <moraesjeremias@gmail.com>